### PR TITLE
XSPF playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ These options determine the behavior of the videowall:
 
   Example: `./play_videowall.sh -c 2e003b`
 
-- `-f <string>`  
-  Set the filename to `<string>`. Should be in format `filename.m3u`. (Defaults to name of current folder.)
+- `-f <format>`  
+  Set the playlist format to `<format>`. Options: `m3u`, `xspf`. (Defaults to `m3u`.)
 
-  Example: `./play_videowall.sh -f party.m3u`
+  Example: `./play_videowall.sh -f xspf`
 
 - `-r`  
   Include video files in subfolders (recursively).

--- a/build_playlist.py
+++ b/build_playlist.py
@@ -28,19 +28,24 @@ intended_playlist_duration = 4*3600
 if len(sys.argv) >= 3:
     intended_playlist_duration = int(sys.argv[2])*3600
 
-playlist_name = os.path.split(os.getcwd())[1].lower() + ".m3u"
+playlist_name = os.path.split(os.getcwd())[1]
 if len(sys.argv) >= 4:
     playlist_name = sys.argv[3]
 
+playlist_format = "m3u"
+# if len(sys.argv) >= 5:
+#     playlist_format = sys.argv[4]
+playlist_name += f".{playlist_format}"
+
 is_recursive = False
-if len(sys.argv) >= 5 and sys.argv[4] == 'true':
+if len(sys.argv) >= 6 and sys.argv[5] == 'true':
     is_recursive = True
 
 # Get video files
 files = []
-for extension in ["avi", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg"]:
+for video_format in ["avi", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg"]:
     files.extend(glob.glob(
-        ("**/*." if is_recursive else "*.") + extension,
+        ("**/*." if is_recursive else "*.") + video_format,
         recursive = is_recursive))
 file_durations = dict(zip(files,[get_duration(file) for file in files]))
 

--- a/play_videowall.sh
+++ b/play_videowall.sh
@@ -6,20 +6,21 @@ cd "$parent_path"
 
 function help_text {
   echo "Options and arguments:"
-  echo "-c <color>     tint video files; <color> must be 6-digit hexadecimal"
-  echo "-f <filename>  set playlist filename; must be of type '.m3u'"
-  echo "-h             print this help message and exit"
-  echo "-r             include video files in subfolders (recursively)"
-  echo "-t <integer>   set duration of each video to <integer> seconds"
+  echo "-c <color>    tint video files; <color> must be 6-digit hexadecimal"
+  echo "-f <format>   set playlist format ['m3u', 'xspf']"
+  echo "-h            print this help message and exit"
+  echo "-r            include video files in subfolders (recursively)"
+  echo "-t <integer>  set duration of each video to <integer> seconds"
 }
 
 function usage_text {
-  echo "Usage: ./play_videowall.sh [-c <color>] [-f <filename>]"
+  echo "Usage: ./play_videowall.sh [-c <color>] [-f <format>]"
   echo "    [-h] [-r] [-t <integer>]"
 }
 
 # Set defaults
-playlist_name="$(basename "$PWD").m3u"
+playlist_format="m3u"
+playlist_name="$(basename "$PWD")"
 clip_duration_in_seconds=10
 playlist_duration_in_hours=4
 color_tint="3b1e00"
@@ -30,7 +31,7 @@ optstring=":c:f:hrt:"
 while getopts ${optstring} arg; do
   case "${arg}" in
     c) color_tint=${OPTARG};;
-    f) playlist_name=${OPTARG};;
+    f) playlist_format=${OPTARG};;
     h)
       usage_text
       echo
@@ -49,6 +50,6 @@ done
 shift $((OPTIND -1))
 
 echo "Generating playlist..."
-python3 build_playlist.py $clip_duration_in_seconds $playlist_duration_in_hours "$playlist_name" $is_recursive
+python3 build_playlist.py $clip_duration_in_seconds $playlist_duration_in_hours "$playlist_name" $playlist_format $is_recursive
 echo "Playing playlist..."
-/Applications/VLC.app/Contents/MacOS/VLC --playlist-autostart --fullscreen --no-osd --loop --no-random --no-audio --video-filter "extract{component=0x$color_tint}" "$playlist_name"
+/Applications/VLC.app/Contents/MacOS/VLC --playlist-autostart --fullscreen --no-osd --loop --no-random --no-audio --video-filter "extract{component=0x$color_tint}" "$playlist_name.$playlist_format"


### PR DESCRIPTION
## Problem

Users may not want to generate `.m3u` playlists, because the format:

- has no formal specification
- has been the source of vulnerabilities in various media players
- was originally designed for audio files

## Solution

This PR:

- adds the ability to generate an [XSPF](https://wiki.videolan.org/XSPF/) playlist.
- modifies the behavior of the `-f` flag to specify a playlist's format (`m3u`, `xspf`), instead of its name.